### PR TITLE
Implement use of Cache-Control & Refactor

### DIFF
--- a/lib/AuthenticationError.js
+++ b/lib/AuthenticationError.js
@@ -14,16 +14,16 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  **/
-'use strict';
+'use strict'
 const AuthenticationError = function (message, error) {
-  Error.call(this, message);
-  Error.captureStackTrace(this, this.constructor);
-  this.name = 'AuthenticationError';
-  this.message = message;
-  if (error) this.inner = error;
-};
+  Error.call(this, message)
+  Error.captureStackTrace(this, this.constructor)
+  this.name = 'AuthenticationError'
+  this.message = message
+  if (error) this.inner = error
+}
 
-AuthenticationError.prototype = Object.create(Error.prototype);
-AuthenticationError.prototype.constructor = AuthenticationError;
+AuthenticationError.prototype = Object.create(Error.prototype)
+AuthenticationError.prototype.constructor = AuthenticationError
 
-module.exports = AuthenticationError;
+module.exports = AuthenticationError

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -15,38 +15,37 @@
  *    limitations under the License.
  **/
 'use strict'
-const debug   = require('debug')('byu-jwt-cache')
+const debug = require('debug')('byu-jwt-cache')
 
 module.exports = Cache
 
-function Cache() {
-
+function Cache () {
   const cache = {}
   const data = {
     endTime: null,
     timeoutId: null,
-    ttl: 10,            // 10 minute default
+    ttl: 10, // 10 minute default
     value: null
   }
 
-  process.on('exit', () => shutdown('exit', data))          // app is closing
-  process.on('SIGINT', () => shutdown('SIGINT', data))      // catches ctrl+c event
-  process.on('SIGBREAK', () => shutdown('SIGBREAK', data))  // catches Windows ctrl+c event
-  process.on('SIGUSR1', () => shutdown('SIGUSR1', data))    // catches "kill pid"
-  process.on('SIGUSR2', () => shutdown('SIGUSR2', data))    // catches "kill pid"
+  process.on('exit', () => shutdown('exit', data)) // app is closing
+  process.on('SIGINT', () => shutdown('SIGINT', data)) // catches ctrl+c event
+  process.on('SIGBREAK', () => shutdown('SIGBREAK', data)) // catches Windows ctrl+c event
+  process.on('SIGUSR1', () => shutdown('SIGUSR1', data)) // catches "kill pid"
+  process.on('SIGUSR2', () => shutdown('SIGUSR2', data)) // catches "kill pid"
 
-  cache.clearCache = function() {
+  cache.clearCache = function () {
     clearCache(data)
     clearTimeout(data.timeoutId)
   }
 
-  cache.getCache = function() {
-    const value = data.value;
+  cache.getCache = function () {
+    const value = data.value
     debug('cache retrieved')
     return value
   }
 
-  cache.setCache = function(value) {
+  cache.setCache = function (value) {
     if (data.ttl > 0) {
       data.value = value
       refreshCache(data)
@@ -54,11 +53,11 @@ function Cache() {
     }
   }
 
-  cache.getTTL = function() {
+  cache.getTTL = function () {
     return data.ttl
   }
 
-  cache.setTTL = function(ttl) {
+  cache.setTTL = function (ttl) {
     data.ttl = ttl > 0 ? ttl : 0
     if (Date.now() + ttlInMilliseconds(data) < data.endTime) refreshCache(data)
   }
@@ -66,12 +65,12 @@ function Cache() {
   return cache
 }
 
-function clearCache(data) {
+function clearCache (data) {
   debug('cache cleared')
   data.value = null
 }
 
-function refreshCache(data) {
+function refreshCache (data) {
   debug('cache updated')
   const ttl = ttlInMilliseconds(data)
   clearTimeout(data.timeoutId)
@@ -79,10 +78,10 @@ function refreshCache(data) {
   data.timeoutId = setTimeout(() => clearCache(data), ttl)
 }
 
-function ttlInMilliseconds(data) {
+function ttlInMilliseconds (data) {
   return data.ttl * 60000
 }
 
-function shutdown(mode, data) {
+function shutdown (mode, data) {
   clearTimeout(data.timeoutId)
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,15 +15,15 @@
  *    limitations under the License.
  **/
 'use strict'
-const AuthenticationError   = require('./AuthenticationError')
-const Cache                 = require('./cache')
-const debug                 = require('debug')('byu-jwt')
-const jsonWebToken          = require('jsonwebtoken')
-const request               = require('./request')
-const { promisify }         = require('util')
+const AuthenticationError = require('./AuthenticationError')
+const Cache = require('./cache')
+const debug = require('debug')('byu-jwt')
+const jsonWebToken = require('jsonwebtoken')
+const request = require('./request')
+const { promisify } = require('util')
 
-const pemGetPublicKey       = promisify(require('pem').getPublicKey)
-const jsonWebTokenVerify    = promisify(jsonWebToken.verify)
+const pemGetPublicKey = promisify(require('pem').getPublicKey)
+const jsonWebTokenVerify = promisify(jsonWebToken.verify)
 
 const BYU_JWT_CURRENT = { name: '', key: 'current', header: 'x-jwt-assertion' }
 const BYU_JWT_ORIGINAL = { name: 'Original', key: 'original', header: 'x-jwt-assertion-original' }
@@ -31,14 +31,14 @@ const WELL_KNOWN_URL = 'https://api.byu.edu/.well-known/openid-configuration'
 
 module.exports = ByuJWT
 
-function ByuJWT(options) {
+function ByuJWT (options) {
   const byuJwt = {}
 
   // normalize options
   if (!options) options = {}
-  if (!options.hasOwnProperty('basePath')) options.basePath = ''
-  if (!options.hasOwnProperty('cacheTTL')) options.cacheTTL = 10
-  if (!options.hasOwnProperty('development')) options.development = false
+  if (!Object.hasOwnProperty.call(options, 'basePath')) options.basePath = ''
+  if (!Object.hasOwnProperty.call(options, 'cacheTTL')) options.cacheTTL = 10
+  if (!Object.hasOwnProperty.call(options, 'development')) options.development = false
 
   // validate options
   if (typeof options.cacheTTL !== 'number') throw Error('Option "cacheTTL" must be a number')
@@ -58,52 +58,52 @@ function ByuJWT(options) {
     return authenticate(byuJwt.options, byuJwt.cache, headers)
   }
 
-  byuJwt.authenticateUAPIMiddleware = async function(req, res, next) {
+  byuJwt.authenticateUAPIMiddleware = async function (req, res, next) {
     debug('running authenticateUAPIMiddleware')
     try {
       req.verifiedJWTs = await byuJwt.authenticate(req.headers)
       debug('completed authenticateUAPIMiddleware')
       next()
     } catch (err) {
-        console.error(err.stack)
-        const response = err instanceof AuthenticationError
-          ? { code: 401, message: err.message }
-          : { code: 500, message: 'Error determining authentication' }
-        debug('failed authenticateUAPIMiddleware: ' + err.stack)
-        res.status(response.code).send({ metadata: { validation_response: response } })
-      }
+      console.error(err.stack)
+      const response = err instanceof AuthenticationError
+        ? { code: 401, message: err.message }
+        : { code: 500, message: 'Error determining authentication' }
+      debug('failed authenticateUAPIMiddleware: ' + err.stack)
+      res.status(response.code).send({ metadata: { validation_response: response } })
+    }
   }
 
-  byuJwt.decodeJWT = async function(jwt) {
+  byuJwt.decodeJWT = async function (jwt) {
     return decodeJWT(byuJwt.options, byuJwt.cache, jwt)
   }
 
-  byuJwt.getOpenIdConfiguration = function() {
+  byuJwt.getOpenIdConfiguration = function () {
     return getOpenIdConfiguration(byuJwt.cache)
   }
 
-  byuJwt.getPublicKey = async function() {
+  byuJwt.getPublicKey = async function () {
     return initPublicKey(byuJwt.cache)
   }
 
-  byuJwt.verifyJWT = async function(jwt) {
-      try {
-        await verifyJWT(byuJwt.options, byuJwt.cache, jwt)
-        return true
-      } catch (e) {
-        return false
-      }
+  byuJwt.verifyJWT = async function (jwt) {
+    try {
+      await verifyJWT(byuJwt.options, byuJwt.cache, jwt)
+      return true
+    } catch (e) {
+      return false
+    }
   }
 
   Object.defineProperties(byuJwt, {
     cacheTTL: {
       get: () => ({
-          openId: byuJwt.cache.openId.getTTL(),
-          byuCert: byuJwt.cache.byuCert.getTTL()
+        openId: byuJwt.cache.openId.getTTL(),
+        byuCert: byuJwt.cache.byuCert.getTTL()
       }),
       set: (ttl) => ({
-          openId: byuJwt.cache.openId.setTTL(ttl),
-          byuCert: byuJwt.cache.byuCert.setTTL(ttl)
+        openId: byuJwt.cache.openId.setTTL(ttl),
+        byuCert: byuJwt.cache.byuCert.setTTL(ttl)
       })
     },
     openIdTTL: {
@@ -120,45 +120,45 @@ function ByuJWT(options) {
 }
 
 Object.defineProperties(ByuJWT, {
-  'BYU_JWT_HEADER_CURRENT': {
+  BYU_JWT_HEADER_CURRENT: {
     value: BYU_JWT_CURRENT.header,
     writable: false
   },
 
-  'BYU_JWT_HEADER_ORIGINAL': {
+  BYU_JWT_HEADER_ORIGINAL: {
     value: BYU_JWT_ORIGINAL.header,
     writable: false
   },
 
-  'AuthenticationError': {
+  AuthenticationError: {
     value: AuthenticationError,
     writable: false
   },
 
-  'JsonWebTokenError': {
+  JsonWebTokenError: {
     value: jsonWebToken.JsonWebTokenError,
     writable: false
   },
 
-  'NotBeforeError': {
+  NotBeforeError: {
     value: jsonWebToken.NotBeforeError,
     writable: false
   },
 
-  'TokenExpiredError': {
+  TokenExpiredError: {
     value: jsonWebToken.TokenExpiredError,
     writable: false
   },
 
-  'WELL_KNOWN_URL': {
+  WELL_KNOWN_URL: {
     value: WELL_KNOWN_URL,
     writable: false
   }
 })
 
-async function authenticate(options, cache, headers) {
+async function authenticate (options, cache, headers) {
   const verifiedJWTs = {}
-  await Promise.all([BYU_JWT_ORIGINAL, BYU_JWT_CURRENT].map(async ({header, name, key}) => {
+  await Promise.all([BYU_JWT_ORIGINAL, BYU_JWT_CURRENT].map(async ({ header, name, key }) => {
     if (headers[header]) {
       debug('verifying JWT in header ' + header)
       try {
@@ -200,54 +200,54 @@ async function authenticate(options, cache, headers) {
  * @param {string} jwt
  * @returns {Promise.<Object>}
  */
-async function decodeJWT(options, cache, jwt) {
+async function decodeJWT (options, cache, jwt) {
   const verifiedJWT = await verifyJWT(options, cache, jwt)
-  const hasResourceOwner = typeof verifiedJWT['http://byu.edu/claims/resourceowner_byu_id'] !== "undefined"
+  const hasResourceOwner = typeof verifiedJWT['http://byu.edu/claims/resourceowner_byu_id'] !== 'undefined'
   const result = {
     client: {
-      byuId:              verifiedJWT['http://byu.edu/claims/client_byu_id'],
-      claimSource:        verifiedJWT['http://byu.edu/claims/client_claim_source'],
-      netId:              verifiedJWT['http://byu.edu/claims/client_net_id'],
-      personId:           verifiedJWT['http://byu.edu/claims/client_person_id'],
+      byuId: verifiedJWT['http://byu.edu/claims/client_byu_id'],
+      claimSource: verifiedJWT['http://byu.edu/claims/client_claim_source'],
+      netId: verifiedJWT['http://byu.edu/claims/client_net_id'],
+      personId: verifiedJWT['http://byu.edu/claims/client_person_id'],
       preferredFirstName: verifiedJWT['http://byu.edu/claims/client_preferred_first_name'],
-      prefix:             verifiedJWT['http://byu.edu/claims/client_name_prefix'],
-      restOfName:         verifiedJWT['http://byu.edu/claims/client_rest_of_name'],
-      sortName:           verifiedJWT['http://byu.edu/claims/client_sort_name'],
-      subscriberNetId:    verifiedJWT['http://byu.edu/claims/client_subscriber_net_id'],
-      suffix:             verifiedJWT['http://byu.edu/claims/client_name_prefix'],
-      surname:            verifiedJWT['http://byu.edu/claims/client_surname'],
-      surnamePosition:    verifiedJWT['http://byu.edu/claims/client_surname_position']
+      prefix: verifiedJWT['http://byu.edu/claims/client_name_prefix'],
+      restOfName: verifiedJWT['http://byu.edu/claims/client_rest_of_name'],
+      sortName: verifiedJWT['http://byu.edu/claims/client_sort_name'],
+      subscriberNetId: verifiedJWT['http://byu.edu/claims/client_subscriber_net_id'],
+      suffix: verifiedJWT['http://byu.edu/claims/client_name_prefix'],
+      surname: verifiedJWT['http://byu.edu/claims/client_surname'],
+      surnamePosition: verifiedJWT['http://byu.edu/claims/client_surname_position']
     },
     ...(hasResourceOwner && {
       resourceOwner: {
-        byuId:              verifiedJWT['http://byu.edu/claims/resourceowner_byu_id'],
-        netId:              verifiedJWT['http://byu.edu/claims/resourceowner_net_id'],
-        personId:           verifiedJWT['http://byu.edu/claims/resourceowner_person_id'],
+        byuId: verifiedJWT['http://byu.edu/claims/resourceowner_byu_id'],
+        netId: verifiedJWT['http://byu.edu/claims/resourceowner_net_id'],
+        personId: verifiedJWT['http://byu.edu/claims/resourceowner_person_id'],
         preferredFirstName: verifiedJWT['http://byu.edu/claims/resourceowner_preferred_first_name'],
-        prefix:             verifiedJWT['http://byu.edu/claims/resourceowner_prefix'],
-        restOfName:         verifiedJWT['http://byu.edu/claims/resourceowner_rest_of_name'],
-        sortName:           verifiedJWT['http://byu.edu/claims/resourceowner_sort_name'],
-        suffix:             verifiedJWT['http://byu.edu/claims/resourceowner_suffix'],
-        surname:            verifiedJWT['http://byu.edu/claims/resourceowner_surname'],
-        surnamePosition:    verifiedJWT['http://byu.edu/claims/resourceowner_surname_position']
+        prefix: verifiedJWT['http://byu.edu/claims/resourceowner_prefix'],
+        restOfName: verifiedJWT['http://byu.edu/claims/resourceowner_rest_of_name'],
+        sortName: verifiedJWT['http://byu.edu/claims/resourceowner_sort_name'],
+        suffix: verifiedJWT['http://byu.edu/claims/resourceowner_suffix'],
+        surname: verifiedJWT['http://byu.edu/claims/resourceowner_surname'],
+        surnamePosition: verifiedJWT['http://byu.edu/claims/resourceowner_surname_position']
       }
     }),
     raw: verifiedJWT,
     wso2: {
-      apiContext:         verifiedJWT["http://wso2.org/claims/apicontext"],
+      apiContext: verifiedJWT['http://wso2.org/claims/apicontext'],
       application: {
-        id:               verifiedJWT["http://wso2.org/claims/applicationid"],
-        name:             verifiedJWT["http://wso2.org/claims/applicationname"],
-        tier:             verifiedJWT["http://wso2.org/claims/applicationtier"]
+        id: verifiedJWT['http://wso2.org/claims/applicationid'],
+        name: verifiedJWT['http://wso2.org/claims/applicationname'],
+        tier: verifiedJWT['http://wso2.org/claims/applicationtier']
       },
-      clientId:           verifiedJWT["http://wso2.org/claims/client_id"],
-      endUser:            verifiedJWT["http://wso2.org/claims/enduser"],
-      endUserTenantId:    verifiedJWT["http://wso2.org/claims/enduserTenantId"],
-      keyType:            verifiedJWT["http://wso2.org/claims/keytype"],
-      subscriber:         verifiedJWT["http://wso2.org/claims/subscriber"],
-      tier:               verifiedJWT["http://wso2.org/claims/tier"],
-      userType:           verifiedJWT["http://wso2.org/claims/usertype"],
-      version:            verifiedJWT["http://wso2.org/claims/version"]
+      clientId: verifiedJWT['http://wso2.org/claims/client_id'],
+      endUser: verifiedJWT['http://wso2.org/claims/enduser'],
+      endUserTenantId: verifiedJWT['http://wso2.org/claims/enduserTenantId'],
+      keyType: verifiedJWT['http://wso2.org/claims/keytype'],
+      subscriber: verifiedJWT['http://wso2.org/claims/subscriber'],
+      tier: verifiedJWT['http://wso2.org/claims/tier'],
+      userType: verifiedJWT['http://wso2.org/claims/usertype'],
+      version: verifiedJWT['http://wso2.org/claims/version']
     }
   }
   result.claims = hasResourceOwner ? result.resourceOwner : result.client
@@ -259,7 +259,7 @@ async function decodeJWT(options, cache, jwt) {
  * Get the latest OpenID configuration and refresh cache
  * @param cache
  */
-async function getOpenIdConfiguration(cache) {
+async function getOpenIdConfiguration (cache) {
   debug('get OpenID configuration')
   try {
     const config = await request(WELL_KNOWN_URL)
@@ -280,17 +280,17 @@ async function getOpenIdConfiguration(cache) {
  * @param {object} cache
  * @returns {string}
  */
-async function getPublicKey(cache) {
+async function getPublicKey (cache) {
   debug('getting public key')
   const openIdConfig = await initOpenId(cache)
   try {
-    const result = await request(openIdConfig["jwks_uri"])
+    const result = await request(openIdConfig.jwks_uri)
     const cert =
-      "-----BEGIN CERTIFICATE-----\n" +
-      result.body.keys[0].x5c[0].replace(/(.{64})/g, "$1\n") +
-      "\n-----END CERTIFICATE-----"
+      '-----BEGIN CERTIFICATE-----\n' +
+      result.body.keys[0].x5c[0].replace(/(.{64})/g, '$1\n') +
+      '\n-----END CERTIFICATE-----'
 
-    //extract public key
+    // extract public key
     const { publicKey } = await pemGetPublicKey(cert)
     debug('public key acquired')
     const maxAge = getMaxAge(result.headers)
@@ -310,13 +310,13 @@ async function getPublicKey(cache) {
  * @params {object} headers
  * @returns {number}
  */
-function getMaxAge(headers) {
+function getMaxAge (headers) {
   debug('getting max age from cache control header')
   const cacheControl = headers['cache-control']
-  let [_, maxAge] = cacheControl.match(/max-age=(\d+)/)
+  let [, maxAge] = cacheControl.match(/max-age=(\d+)/) // Get digits
   maxAge = parseInt(maxAge, 10)
   if (!maxAge) {
-    debug(`defaulting max age to 3600`)
+    debug('defaulting max age to 3600')
     return 3600
   }
   debug(`max age is ${maxAge}`)
@@ -328,7 +328,7 @@ function getMaxAge(headers) {
  * @params {number} seconds
  * @returns {number}
  */
-function maxAgeInMinutes(seconds) {
+function maxAgeInMinutes (seconds) {
   return Math.floor(seconds / 60)
 }
 
@@ -337,11 +337,11 @@ function maxAgeInMinutes(seconds) {
  * @param {object} cache
  * @returns {object}
  */
-function initOpenId(cache) {
+function initOpenId (cache) {
   return cache.openId.getCache() || getOpenIdConfiguration(cache)
 }
 
-async function initPublicKey(cache) {
+async function initPublicKey (cache) {
   return cache.byuCert.getCache() || getPublicKey(cache)
 }
 
@@ -352,7 +352,7 @@ async function initPublicKey(cache) {
  * @param {string} jwt
  * @returns {Promise<Object>}
  */
-async function verifyJWT(options, cache, jwt) {
+async function verifyJWT (options, cache, jwt) {
   // we can skip verification
   if (options.development) {
     console.error('WARNING: JWT verification skipped in development mode')
@@ -361,7 +361,7 @@ async function verifyJWT(options, cache, jwt) {
   }
 
   const openIdConfig = await initOpenId(cache)
-  const algorithms = openIdConfig["id_token_signing_alg_values_supported"]
+  const algorithms = openIdConfig.id_token_signing_alg_values_supported
   const publicKey = await getPublicKey(cache)
 
   debug('verifying JWT')

--- a/lib/request.js
+++ b/lib/request.js
@@ -15,17 +15,17 @@
  *    limitations under the License.
  **/
 'use strict'
-const debug           = require('debug')('byu-jwt-request')
-const http            = require('http')
-const https           = require('https')
+const debug = require('debug')('byu-jwt-request')
+const http = require('http')
+const https = require('https')
 
 /**
  * Make a simple HTTP or HTTPS GET request.
  * @param {string} url
  * @returns {Promise<{ body: Object, headers: Object }>}
  */
-module.exports = function request(url) {
-  debug('making request to ' + url);
+module.exports = function request (url) {
+  debug('making request to ' + url)
   return new Promise((resolve, reject) => {
     const mod = /^https/.test(url) ? https : http
     const req = mod.get(url, res => {
@@ -35,9 +35,9 @@ module.exports = function request(url) {
         data += chunk.toString()
       })
       res.on('end', () => {
-        debug('completed request to ' + url);
+        debug('completed request to ' + url)
         let body
-        let headers = res.headers
+        const headers = res.headers
         try {
           body = JSON.parse(data)
         } catch (err) {
@@ -48,7 +48,7 @@ module.exports = function request(url) {
     })
 
     req.on('error', err => {
-      debug('failed request to ' + url);
+      debug('failed request to ' + url)
       reject(err)
     })
   })

--- a/package.json
+++ b/package.json
@@ -13,18 +13,20 @@
     "url": "https://github.com/byu-oit/byu-jwt-nodejs/issues"
   },
   "scripts": {
-    "test": "mocha test"
+    "test": "mocha test",
+    "lint": "./node_modules/.bin/standard --fix"
   },
   "homepage": "https://github.com/byu-oit/byu-jwt-nodejs#readme",
   "dependencies": {
     "debug": "^4.1.1",
     "jsonwebtoken": "^8.5.1",
-    "pem": "^1.14.2"
+    "pem": "^1.14.3"
   },
   "devDependencies": {
     "aws-sdk": "^2.578.0",
     "chai": "^4.2.0",
     "mocha": "^6.2.2",
-    "request": "^2.88.0"
+    "request": "^2.88.0",
+    "standard": "^14.3.1"
   }
 }


### PR DESCRIPTION
This PR includes:
- :fire: Make use of Cache-Control (max-age) header to manage the cache TTL
- :heavy_plus_sign: Now Caches the public key as well
- :green_heart: Add Standard JS Linter for consistent code style