### PR TITLE
Remove replace for local dev

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,6 @@ function ByuJWT (options) {
     } catch (err) {
       const cleanedStack = err.stack
         .replace(/\r\n/g, '\r')
-        .replace(/\n/g, '\r')
       console.error('[ByuJWT]', cleanedStack)
       const response = err instanceof AuthenticationError
         ? { code: 401, message: err.message }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "byu-jwt",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "The byu-jwt module provides helpful functions to retrieve a specified BYU .well-known URL and verify BYU signed JWTs.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
I know I was the person who added these lines of code, but the second line creates an issue when running locally. Including it will only show the final line of the stack trace rather than the clear stack traces. This fixes that, but I don't know how it will affect logging in CloudWatch (which was the original issue). If you have any ideas of how to test this in CloudWatch before merging, I'm open to them.

